### PR TITLE
Fix redirect in authorize

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,6 @@ import Profile from "./components/Profile";
 import Authorize from "./components/Authorize";
 
 const App = () => {
-  // The useStytchUser hook will return the existing Stytch User object if one exists
   const { user, fromCache } = useStytchUser();
 
   return (

--- a/src/components/Authorize.js
+++ b/src/components/Authorize.js
@@ -1,16 +1,14 @@
-import { Redirect } from 'react';
+import { Navigate } from 'react-router-dom';
 import { IdentityProvider, useStytchUser } from '@stytch/react';
 
 const Authorize = () => {
   const { user } = useStytchUser();
 
   if (!user) {
-    const loginURL = `/?returnTo=${window.location.toString()}`
-    return <Redirect to={loginURL} />
+    return <Navigate to="/" replace />;
   }
 
-  return <IdentityProvider />
-
+  return <IdentityProvider />;
 };
 
 export default Authorize; 


### PR DESCRIPTION
The redirect to login in Authorize was broken; use Navigate instead of Redirect.