### PR TITLE
Fix bug where the token keeps trying to authenticate, and fix styling on Authorize page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
       content="An example React application using Stytch for authentication"
     />
     <title>Stytch React Example</title>
-    <link rel="stylesheet" href="stytch.css" />
+    <link rel="stylesheet" href="/stytch.css" />
   </head>
   <body>
     <noscript>
@@ -18,12 +18,12 @@
     </noscript>
     <header>
       <a class="header" href="/">
-        <img src="logo.svg" width="190px"/>
+        <img src="/logo.svg" width="190px"/>
       </a>
       <div class="link-container">
         <a class="header" target="_blank" href="https://www.stytch.com/docs">Stytch Docs</a>
         <a class="header" target="_blank" href="https://github.com/stytchauth/stytch-react-example">
-          <img src="github.svg" width="20px" style="margin-right: 4px;"></img>
+          <img src="/github.svg" width="20px" style="margin-right: 4px;"></img>
           View on Github 
         </a>
       </div>

--- a/src/components/TokenAuthenticator.js
+++ b/src/components/TokenAuthenticator.js
@@ -23,13 +23,17 @@ const TokenAuthenticator = ({ children }) => {
       // If a token is found, authenticate it with the appropriate method
       if (token && tokenType) {
         if (tokenType === "magic_links") {
-          stytch.magicLinks.authenticate(token, {
-            session_duration_minutes: 60,
-          });
+          stytch.magicLinks
+            .authenticate(token, {
+              session_duration_minutes: 60,
+            })
+            .then(() => (window.location.href = "/"));
         } else if (tokenType === "oauth") {
-          stytch.oauth.authenticate(token, {
-            session_duration_minutes: 60,
-          });
+          stytch.oauth
+            .authenticate(token, {
+              session_duration_minutes: 60,
+            })
+            .then(() => (window.location.href = "/"));
         }
       }
     }


### PR DESCRIPTION
Was running into an issue where I got an email magic links error when I logged in, because the token info was still in the url and it called authenticate again in TokenAuthenticator. This is a super small change that will redirect back to home page instead of keeping the token url